### PR TITLE
Add class decorator interface description in decorator intro section

### DIFF
--- a/decorators.html
+++ b/decorators.html
@@ -44,7 +44,7 @@ contributors: Yehuda Katz, Brian Terlson, Ecma International
     <pre><code class="typescript">
       interface ClassDesciptor {
         klass: Function;
-        parent: Function;
+        parent: Function|undefined;
         members: MemberDescriptor[];
       }
     </code></pre>

--- a/decorators.html
+++ b/decorators.html
@@ -32,15 +32,22 @@ contributors: Yehuda Katz, Brian Terlson, Ecma International
     <p>A <dfn>member decorator function</dfn> is a function which takes a member descriptor and which returns a member descriptor. A <dfn>member descriptor</dfn> is similar to a property descriptor and has the following shape:</p>
     <pre><code class="typescript">
       interface MemberDesciptor {
-        kind: "Property"
-        key: string,
-        isStatic: boolean,
-        descriptor: PropertyDescriptor,
-        extras?: MemberDescriptor[]
+        kind: "Property";
+        key: string;
+        isStatic: boolean;
+        descriptor: PropertyDescriptor;
+        extras?: MemberDescriptor[];
         finisher?: (klass): void;
       }
     </code></pre>
     <p>A <dfn>class decorator function</dfn> is a function which takes a constructor, heritage (parent class), and an array of MemberDescriptors that represent the instance and static members of the class.</p>
+    <pre><code class="typescript">
+      interface ClassDesciptor {
+        klass: Function;
+        parent: Function;
+        members: MemberDescriptor[];
+      }
+    </code></pre>
 
     <pre><code>
       function configurable(val) {

--- a/decorators.html
+++ b/decorators.html
@@ -32,7 +32,7 @@ contributors: Yehuda Katz, Brian Terlson, Ecma International
     <p>A <dfn>member decorator function</dfn> is a function which takes a member descriptor and which returns a member descriptor. A <dfn>member descriptor</dfn> is similar to a property descriptor and has the following shape:</p>
     <pre><code class="typescript">
       interface MemberDesciptor {
-        kind: "Property";
+        kind: "property";
         key: string;
         isStatic: boolean;
         descriptor: PropertyDescriptor;


### PR DESCRIPTION
I noticed that the [member descriptors had one](https://tc39.github.io/proposal-decorators/#sec-intro-decorator-functions), so I felt class descriptors needed one as well.

As a drive-by, I fixed descriptor interface grammar (where it's in TypeScript).
